### PR TITLE
fix minor typo (handel => handle)

### DIFF
--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -220,9 +220,9 @@ export type DragOptions = {
 	 *
 	 * @example
 	 * <!-- Grid has a handle element -->
-	 * <div use:draggable={{ handle: '.handel' }}>
+	 * <div use:draggable={{ handle: '.handle' }}>
 	 *   This won't drag
-	 *   <div class="handel">This sure will drag!!</div>
+	 *   <div class="handle">This sure will drag!!</div>
 	 * </div>
 	 * ```
 	 */


### PR DESCRIPTION
Fixes some inconsistent terminology/spelling in the JSDoc examples.