### PR TITLE
recalculate computedBounds if bounds updated

### DIFF
--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -471,6 +471,11 @@ export const draggable = (node: HTMLElement, options: DragOptions = {}) => {
 
 			nodeClassList.add(defaultClass);
 
+			// Compute bounds
+			if (typeof bounds !== 'undefined') {
+				computedBounds = computeBoundRect(bounds, node);
+			}
+
 			if (dragged) nodeClassList.add(defaultClassDragged);
 
 			if (isControlled) {


### PR DESCRIPTION
If bounds updated we should recalculate computedBounds.
We calculate computedBounds onDragStart event, and using computedBounds in onDrag event. But bounds could be updated when user dragging. So in short, every time bounds updated we should update computedBounds too.
