### PR TITLE
Custom bounding and render

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,12 +14,16 @@ export type DragBoundsCoords = {
 
 export type DragAxis = 'both' | 'x' | 'y' | 'none';
 
-export type DragBounds =
+export type DragBoundsPrimitive =
 	| HTMLElement
 	| Partial<DragBoundsCoords>
 	| 'parent'
 	| 'body'
 	| (string & Record<never, never>);
+
+export type DragBounds =
+	| DragBoundsPrimitive
+	| (() => DragBoundsPrimitive);
 
 export type DragEventData = {
 	/** How much element moved from its original position horizontally */
@@ -46,9 +50,15 @@ export type DragOptions = {
 	 * **Note**: We don't check whether the selector is bigger than the node element.
 	 * You yourself will have to make sure of that, or it may lead to strange behavior
 	 *
-	 * Or, finally, you can pass an object of type `{ top: number; right: number; bottom: number; left: number }`.
+	 * Or, you can pass an HTMLElement.
+	 *
+	 * Or, you can pass an object of type `{ top: number; right: number; bottom: number; left: number }`.
 	 * These mimic the css `top`, `right`, `bottom` and `left`, in the sense that `bottom` starts from the bottom of the window, and `right` from right of window.
 	 * If any of these properties are unspecified, they are assumed to be `0`.
+	 *
+	 * Or, finally, you can pass a function that returns any of the above. This is useful,
+	 * for example, when you are bounding the drag area to a component that is not yet
+	 * mounted, but will be by the time the drag starts.
 	 */
 	bounds?: DragBounds;
 
@@ -611,6 +621,10 @@ const cancelElementContains = (cancelElements: HTMLElement[], dragElements: HTML
 
 function computeBoundRect(bounds: DragOptions['bounds'], rootNode: HTMLElement) {
 	if (bounds === undefined) return;
+
+	if (typeof bounds === 'function') {
+		bounds = bounds();
+	}
 
 	if (isHTMLElement(bounds)) return bounds.getBoundingClientRect();
 


### PR DESCRIPTION
Hey, thanks for making this great project! I had to customize it slightly for my own use case. Just letting you see what I did in case you're interested in incorporating this upstream.

Changes made:

- Existing option to use an arbitrary `HTMLElement` as `DragBounds` doesn't appear to be documented, so I added that
- Add function as input type for `DragBounds`. This is because the variable bound to an `HTMLElement` will be `undefined` [until the component mounts](https://learn.svelte.dev/tutorial/bind-this), and therefore cannot be passed in directly to neodrag at component mount time
- Allow for custom render function. I have multiple elements that must be moved at the same time, that are already positioned using the `left` attribute. I'd rather keep the existing CSS instead of moving to `transform`, and I also need to coordinate changing the positioning for multiple elements simultaneously with no lag.