### PR TITLE
feat: Expose PointerEvent

### DIFF
--- a/.changeset/new-cooks-yell.md
+++ b/.changeset/new-cooks-yell.md
@@ -1,0 +1,10 @@
+---
+'@neodrag/core': minor
+'@neodrag/react': minor
+'@neodrag/solid': minor
+'@neodrag/svelte': minor
+'@neodrag/vanilla': minor
+'@neodrag/vue': minor
+---
+
+feat: Expose event: PointerEvent

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -1,0 +1,24 @@
+name: Continuous Releases
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: true
+
+      - name: Compile
+        run: pnpm compile
+
+      - name: Release
+        run: pnpm dlx pkg-pr-new publish

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -21,4 +21,4 @@ jobs:
         run: pnpm compile
 
       - name: Release
-        run: pnpm dlx pkg-pr-new publish
+        run: pnpm dlx pkg-pr-new publish './packages/*'

--- a/docs/src/documentation/exported-types.mdx
+++ b/docs/src/documentation/exported-types.mdx
@@ -42,6 +42,9 @@ export type DragEventData = {
 
   /** The element being dragged */
   currentNode: HTMLElement;
+
+  /** The pointer event that triggered the drag */
+  event: PointerEvent;
 };
 
 export type DragBoundsCoords = {

--- a/docs/src/pages/docs/svelte.mdx
+++ b/docs/src/pages/docs/svelte.mdx
@@ -102,13 +102,13 @@ How to use events-as-options? The syntax is similar to the custom events one ðŸ‘
 ```svelte
 <div
   use:draggable={{
-    onDragStart: ({ offsetX, offsetY, rootNode, currentNode }) => {
+    onDragStart: ({ offsetX, offsetY, rootNode, currentNode, event }) => {
       // Do something
     },
-    onDrag: ({ offsetX, offsetY, rootNode, currentNode }) => {
+    onDrag: ({ offsetX, offsetY, rootNode, currentNode, event }) => {
       // Do something
     },
-    onDragEnd: ({ offsetX, offsetY, rootNode, currentNode }) => {
+    onDragEnd: ({ offsetX, offsetY, rootNode, currentNode, event }) => {
       // Do something
     },
   }}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -342,7 +342,7 @@ export function draggable(node: HTMLElement, options: DragOptions = {}) {
 
 	let active_pointers = new Set<number>();
 
-	function try_start_drag() {
+	function try_start_drag(event: PointerEvent) {
 		if (
 			is_interacting &&
 			!is_dragging &&
@@ -351,7 +351,7 @@ export function draggable(node: HTMLElement, options: DragOptions = {}) {
 			currently_dragged_el
 		) {
 			is_dragging = true;
-			fire_svelte_drag_start_event();
+			fire_svelte_drag_start_event(event);
 			node_class_list.add(defaultClassDragging);
 
 			if (applyUserSelectHack) {
@@ -393,31 +393,32 @@ export function draggable(node: HTMLElement, options: DragOptions = {}) {
 		}
 	}
 
-	function get_event_data() {
+	function get_event_data(event: PointerEvent) {
 		return {
 			offsetX: translate_x,
 			offsetY: translate_y,
 			rootNode: node,
 			currentNode: currently_dragged_el,
+			event
 		};
 	}
 
-	function call_event(eventName: 'neodrag:start' | 'neodrag' | 'neodrag:end', fn: typeof onDrag) {
-		const data = get_event_data();
+	function call_event(eventName: 'neodrag:start' | 'neodrag' | 'neodrag:end', fn: typeof onDrag, event: PointerEvent) {
+		const data = get_event_data(event);
 		node.dispatchEvent(new CustomEvent(eventName, { detail: data }));
 		fn?.(data);
 	}
 
-	function fire_svelte_drag_start_event() {
-		call_event('neodrag:start', onDragStart);
+	function fire_svelte_drag_start_event(event: PointerEvent) {
+		call_event('neodrag:start', onDragStart, event);
 	}
 
-	function fire_svelte_drag_end_event() {
-		call_event('neodrag:end', onDragEnd);
+	function fire_svelte_drag_end_event(event: PointerEvent) {
+		call_event('neodrag:end', onDragEnd, event);
 	}
 
-	function fire_svelte_drag_event() {
-		call_event('neodrag', onDrag);
+	function fire_svelte_drag_event(event: PointerEvent) {
+		call_event('neodrag', onDrag, event);
 	}
 
 	const listen = addEventListener;
@@ -502,7 +503,7 @@ export function draggable(node: HTMLElement, options: DragOptions = {}) {
 					const elapsed = Date.now() - start_time;
 					if (elapsed >= threshold.delay!) {
 						meets_time_threshold = true;
-						try_start_drag();
+						try_start_drag(e);
 					}
 				}
 
@@ -514,7 +515,7 @@ export function draggable(node: HTMLElement, options: DragOptions = {}) {
 
 					if (distance >= threshold.distance!) {
 						meets_distance_threshold = true;
-						try_start_drag();
+						try_start_drag(e);
 					}
 				}
 
@@ -574,7 +575,7 @@ export function draggable(node: HTMLElement, options: DragOptions = {}) {
 			x_offset = translate_x;
 			y_offset = translate_y;
 
-			fire_svelte_drag_event();
+			fire_svelte_drag_event(e);
 
 			set_translate();
 		},
@@ -604,7 +605,7 @@ export function draggable(node: HTMLElement, options: DragOptions = {}) {
 
 				if (applyUserSelectHack) body_style.userSelect = body_original_user_select_val;
 
-				fire_svelte_drag_end_event();
+				fire_svelte_drag_end_event(e);
 
 				if (can_move_in_x) initial_x = translate_x;
 				if (can_move_in_y) initial_y = translate_y;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,9 @@ export type DragEventData = {
 
 	/** The element being dragged */
 	currentNode: HTMLElement;
+
+	/** The pointer event that triggered the drag */
+	event: PointerEvent;
 };
 
 export type DragOptions = {


### PR DESCRIPTION
This exposes `event: PointerEvent` on DragEventData object. This is the PointerEvent that triggered this specific drag.

One notable thing is that onDragMove and onDragEnd will report pointermove and pointerup events, however onDragStart will report pointermove itself rather than pointerdown, simply because of the threshold logic