### PR TITLE
fix: import @neodrag in a svelte project

### DIFF
--- a/.changeset/dull-jeans-flash.md
+++ b/.changeset/dull-jeans-flash.md
@@ -1,0 +1,5 @@
+---
+'@neodrag/svelte': patch
+---
+
+fix: (vite) Failed to resolve entry for package "@neodrag/svelte". Adding "svelte": "./dist/min/index.js" in pacakge.json fixes the issue.

--- a/.changeset/dull-jeans-flash.md
+++ b/.changeset/dull-jeans-flash.md
@@ -2,4 +2,4 @@
 '@neodrag/svelte': patch
 ---
 
-fix: (vite) Failed to resolve entry for package "@neodrag/svelte". Adding "svelte": "./dist/min/index.js" in pacakge.json fixes the issue.
+fix: Add "svelte" field to @neodrag/svelte exports

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -17,7 +17,8 @@
 				"production": "./dist/min/index.js",
 				"development": "./dist/index.js"
 			},
-			"default": "./dist/min/index.js"
+			"default": "./dist/min/index.js",
+      		"svelte": "./dist/min/index.js"
 		},
 		"./package.json": "./package.json"
 	},


### PR DESCRIPTION
I got this vite error after updating packages (svelte, kit, vite etc.).

![image](https://github.com/user-attachments/assets/fecd79b0-d4bf-405e-89ec-a09c6320415b)

> Failed to resolve entry for package "@neodrag/svelte". The package may have incorrect main/module/exports specified in its package.json: No known conditions for "." specifier in "@neodrag/svelte" package

Adding `"svelte": "./dist/min/index.js"` in package.json solves the issue.

```diff
".": {
    "types": "./dist/index.d.ts",
    "import": {
	"production": "./dist/min/index.js",
	"development": "./dist/index.js"
     },
     "default": "./dist/min/index.js",
+     "svelte": "./dist/min/index.js"
},
```
