### PR TITLE
Compartments

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -680,25 +680,27 @@ export function createDraggable({
 				// Manual mode
 				const resolved = plugins();
 				// First resolve compartments into their current plugins
-				const resolvedPlugins = resolve_plugins(resolved, instance.compartments);
+				const resolved_plugins = resolve_plugins(resolved, instance.compartments);
 				// Then initialize plugins properly, including sorting and defaults
-				instance.plugins = initialize_plugins(resolvedPlugins);
+				instance.plugins = initialize_plugins(resolved_plugins);
 
 				// Set up compartment subscriptions
 				resolved.forEach((item) => {
 					if (item instanceof Compartment) {
 						item.subscribe((newPlugin) => {
-							const oldPlugin = instance.plugins.find((p) => instance.compartments.get(item) === p);
-							if (oldPlugin) {
+							const old_plugin = instance.plugins.find(
+								(p) => instance.compartments.get(item) === p,
+							);
+							if (old_plugin) {
 								// We update the plugin reference
-								instance.plugins[instance.plugins.indexOf(oldPlugin)] = newPlugin;
+								instance.plugins[instance.plugins.indexOf(old_plugin)] = newPlugin;
 								instance.compartments.set(item, newPlugin);
 
 								// But we're not properly handling the position update
 								// We need to:
 								// 1. Clean up the old plugin state
-								oldPlugin.cleanup?.(instance.ctx, instance.states.get(oldPlugin.name));
-								instance.states.delete(oldPlugin.name);
+								old_plugin.cleanup?.(instance.ctx, instance.states.get(old_plugin.name));
+								instance.states.delete(old_plugin.name);
 
 								// 2. Set up the new plugin state
 								const state = newPlugin.setup?.(instance.ctx);

--- a/packages/core/src/plugins.ts
+++ b/packages/core/src/plugins.ts
@@ -42,6 +42,10 @@ export interface Plugin<State = any, Args extends any[] = any[]> {
 	args?: Args;
 }
 
+// Type definitions for the new plugin system
+export type PluginResolver = () => (Plugin | Compartment<any>)[];
+export type PluginInput = Plugin[] | PluginResolver;
+
 interface BasePluginStructure {
 	name: string;
 	priority?: number;
@@ -56,6 +60,46 @@ interface PluginStructure<ArgsTuple extends any[], State> extends BasePluginStru
 	drag?: (args: ArgsTuple, ctx: PluginContext, state: State, event: PointerEvent) => void;
 	end?: (args: ArgsTuple, ctx: PluginContext, state: State, event: PointerEvent) => void;
 	cleanup?: (args: ArgsTuple, ctx: PluginContext, state: State) => void;
+}
+
+export class Compartment<T extends Plugin = Plugin> {
+	#current: T;
+	#subscribers: Set<(plugin: T) => void>;
+
+	// Note: We accept a getter instead of actual value since in svelte u get the warning of state accessed outside closure
+	// This just takes the warning away
+	constructor(initial: () => T) {
+		this.#current = initial();
+		this.#subscribers = new Set();
+	}
+
+	get current(): T {
+		return this.#current;
+	}
+
+	set current(plugin: T) {
+		if (plugin === this.#current) return;
+		this.#current = plugin;
+		this.#subscribers.forEach((callback) => callback(plugin));
+	}
+
+	subscribe(callback: (plugin: T) => void) {
+		this.#subscribers.add(callback);
+		return () => this.#subscribers.delete(callback);
+	}
+}
+
+export function resolve_plugins(
+	items: (Plugin | Compartment)[],
+	compartments: Map<Compartment, Plugin>,
+): Plugin[] {
+	return items.map((item) => {
+		if (item instanceof Compartment) {
+			compartments.set(item, item.current);
+			return item.current;
+		}
+		return item;
+	});
 }
 
 export function unstable_definePlugin<ArgsTuple extends any[], State = void>(

--- a/packages/core/src/plugins.ts
+++ b/packages/core/src/plugins.ts
@@ -28,7 +28,7 @@ export interface PluginContext {
 	setForcedPosition: (x: number, y: number) => void;
 }
 
-export interface Plugin<State = any> {
+export interface Plugin<State = any, Args extends any[] = any[]> {
 	name: string;
 	priority?: number;
 	liveUpdate?: boolean;
@@ -39,7 +39,7 @@ export interface Plugin<State = any> {
 	drag?: (ctx: PluginContext, state: State, event: PointerEvent) => void;
 	end?: (ctx: PluginContext, state: State, event: PointerEvent) => void;
 	cleanup?: (ctx: PluginContext, state: State) => void;
-	args?: any;
+	args?: Args;
 }
 
 interface BasePluginStructure {

--- a/packages/core/test-app/e2e/mode.test.ts
+++ b/packages/core/test-app/e2e/mode.test.ts
@@ -1,0 +1,143 @@
+import test, { expect } from '@playwright/test';
+import { get_mouse_position, setup } from './test-utils';
+import { SCHEMAS } from '../src/lib/schemas';
+
+test('auto', async ({ page }) => {
+	await setup(page, 'mode', SCHEMAS.MODE, {
+		type: 'auto',
+	});
+
+	const div = page.getByTestId('draggable');
+	{
+		await div.hover();
+		const { x, y } = await get_mouse_position(page);
+		await page.mouse.down();
+		await page.mouse.move(x + 100, y + 100);
+		await expect(div).toHaveCSS('translate', '100px');
+		await page.mouse.up();
+	}
+
+	// Now change the axes
+	// const x_radio = page.locator('#x');
+	const y_radio = page.locator('#y');
+
+	// Click on y_radio
+	await y_radio.click();
+
+	{
+		await div.hover();
+		const { x, y } = await get_mouse_position(page);
+		await page.mouse.down();
+		await page.mouse.move(x + 100, y + 100);
+		await expect(div).toHaveCSS('translate', '100px 100px');
+		await page.mouse.up();
+	}
+
+	// Change Grid Y
+	const y_grid = page.locator('#grid_y');
+
+	await y_grid.fill('100');
+
+	{
+		await div.hover();
+		const { x, y } = await get_mouse_position(page);
+		await page.mouse.down();
+		await page.mouse.move(x + 100, y + 130);
+		await expect(div).toHaveCSS('translate', '100px 300px');
+		await page.mouse.up();
+	}
+});
+
+test('manual-false', async ({ page }) => {
+	await setup(page, 'mode', SCHEMAS.MODE, {
+		type: 'manual',
+		works_in_manual: false,
+	});
+
+	const div = page.getByTestId('draggable');
+	{
+		await div.hover();
+		const { x, y } = await get_mouse_position(page);
+		await page.mouse.down();
+		await page.mouse.move(x + 100, y + 100);
+		await expect(div).toHaveCSS('translate', '100px');
+		await page.mouse.up();
+	}
+
+	// Now change the axes
+	// const x_radio = page.locator('#x');
+	const y_radio = page.locator('#y');
+
+	// Click on y_radio
+	await y_radio.click();
+
+	{
+		await div.hover();
+		const { x, y } = await get_mouse_position(page);
+		await page.mouse.down();
+		await page.mouse.move(x + 100, y + 100);
+		await expect(div).toHaveCSS('translate', '200px');
+		await page.mouse.up();
+	}
+
+	// Change Grid Y
+	const y_grid = page.locator('#grid_y');
+
+	await y_grid.fill('100');
+
+	{
+		await div.hover();
+		const { x, y } = await get_mouse_position(page);
+		await page.mouse.down();
+		await page.mouse.move(x + 100, y + 130);
+		await expect(div).toHaveCSS('translate', '300px');
+		await page.mouse.up();
+	}
+});
+
+test('manual-true', async ({ page }) => {
+	await setup(page, 'mode', SCHEMAS.MODE, {
+		type: 'manual',
+		works_in_manual: true,
+	});
+
+	const div = page.getByTestId('draggable');
+	{
+		await div.hover();
+		const { x, y } = await get_mouse_position(page);
+		await page.mouse.down();
+		await page.mouse.move(x + 100, y + 100);
+		await expect(div).toHaveCSS('translate', '100px');
+		await page.mouse.up();
+	}
+
+	// Now change the axes
+	// const x_radio = page.locator('#x');
+	const y_radio = page.locator('#y');
+
+	// Click on y_radio
+	await y_radio.click();
+
+	{
+		await div.hover();
+		const { x, y } = await get_mouse_position(page);
+		await page.mouse.down();
+		await page.mouse.move(x + 100, y + 100);
+		await expect(div).toHaveCSS('translate', '100px 100px');
+		await page.mouse.up();
+	}
+
+	// Change Grid Y
+	const y_grid = page.locator('#grid_y');
+
+	await y_grid.fill('100');
+
+	{
+		await div.hover();
+		const { x, y } = await get_mouse_position(page);
+		await page.mouse.down();
+		await page.mouse.move(x + 100, y + 130);
+		await expect(div).toHaveCSS('translate', '100px 300px');
+		await page.mouse.up();
+	}
+});

--- a/packages/core/test-app/e2e/plugins/threshold.test.ts
+++ b/packages/core/test-app/e2e/plugins/threshold.test.ts
@@ -1,6 +1,6 @@
 import test, { expect } from '@playwright/test';
-import { get_mouse_position, setup, stringify_console_message } from '../test-utils';
 import { SCHEMAS } from '../../src/lib/schemas';
+import { get_mouse_position, setup } from '../test-utils';
 
 test('null disables the plugin', async ({ page }) => {
 	await setup(page, 'plugins/threshold', SCHEMAS.PLUGINS.THRESHOLD, null);

--- a/packages/core/test-app/src/lib/Box.svelte
+++ b/packages/core/test-app/src/lib/Box.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
-	import { createDraggable, DEFAULTS } from '../../../src';
+	import { createDraggable, DEFAULTS, type PluginResolver } from '../../../src';
 	import type { Plugin } from '../../../src/plugins';
 
 	const {
@@ -9,7 +9,7 @@
 		plugins,
 		default_plugins = DEFAULTS.plugins,
 	}: {
-		plugins?: Plugin[];
+		plugins?: Plugin[] | PluginResolver;
 		testid: string;
 		children?: Snippet;
 		default_plugins?: Plugin[];

--- a/packages/core/test-app/src/lib/Box.svelte
+++ b/packages/core/test-app/src/lib/Box.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
-	import { createDraggable, DEFAULTS, type PluginResolver } from '../../../src';
-	import type { Plugin } from '../../../src/plugins';
+	import { createDraggable, DEFAULTS } from '../../../src';
+	import type { Plugin, PluginInput } from '../../../src/plugins';
 
 	const {
 		testid,
@@ -9,7 +9,7 @@
 		plugins,
 		default_plugins = DEFAULTS.plugins,
 	}: {
-		plugins?: Plugin[] | PluginResolver;
+		plugins?: PluginInput;
 		testid: string;
 		children?: Snippet;
 		default_plugins?: Plugin[];

--- a/packages/core/test-app/src/lib/ROUTES.ts
+++ b/packages/core/test-app/src/lib/ROUTES.ts
@@ -11,6 +11,7 @@
 const PAGES = {
   "/": `/`,
   "/defaults": `/defaults`,
+  "/mode": `/mode`,
   "/plugins/applyUserSelectHack": `/plugins/applyUserSelectHack`,
   "/plugins/axis": `/plugins/axis`,
   "/plugins/bounds": `/plugins/bounds`,
@@ -140,7 +141,7 @@ export function route<T extends keyof AllTypes>(key: T, ...params: any[]): strin
 * ```
 */
 export type KIT_ROUTES = {
-  PAGES: { '/': never, '/defaults': never, '/plugins/applyUserSelectHack': never, '/plugins/axis': never, '/plugins/bounds': never, '/plugins/controls': never, '/plugins/grid': never, '/plugins/position': never, '/plugins/threshold': never, '/plugins/touchAction': never, '/plugins/transform': never }
+  PAGES: { '/': never, '/defaults': never, '/mode': never, '/plugins/applyUserSelectHack': never, '/plugins/axis': never, '/plugins/bounds': never, '/plugins/controls': never, '/plugins/grid': never, '/plugins/position': never, '/plugins/threshold': never, '/plugins/touchAction': never, '/plugins/transform': never }
   SERVERS: Record<string, never>
   ACTIONS: Record<string, never>
   LINKS: Record<string, never>

--- a/packages/core/test-app/src/lib/schemas.ts
+++ b/packages/core/test-app/src/lib/schemas.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 
 export const SCHEMAS = {
+	MODE: z.object({
+		type: z.enum(['manual', 'auto']).default('auto'),
+		works_in_manual: z.boolean().default(false),
+	}),
+
 	PLUGINS: {
 		AXIS: z.enum(['x', 'y']).optional(),
 

--- a/packages/core/test-app/src/routes/(test)/mode/+page.server.ts
+++ b/packages/core/test-app/src/routes/(test)/mode/+page.server.ts
@@ -1,0 +1,6 @@
+import { extract_options_from_url } from '$lib/helpers.js';
+import { SCHEMAS } from '$lib/schemas.js';
+
+export function load({ request }) {
+	return extract_options_from_url(request, SCHEMAS.MODE);
+}

--- a/packages/core/test-app/src/routes/(test)/mode/+page.svelte
+++ b/packages/core/test-app/src/routes/(test)/mode/+page.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import Box from '$lib/Box.svelte';
+	import { Compartment } from '../../../../../src/index.js';
+	import { axis, grid } from '../../../../../src/plugins.js';
+
+	const { data } = $props();
+
+	let axis_val = $state<'x' | 'y'>('x');
+	let grid_val = $state<[number, number]>([10, 10]);
+
+	const axis_comp = new Compartment(() => axis(axis_val));
+	const grid_comp = new Compartment(() => grid(grid_val));
+
+	$effect(() => {
+		if (data.type === 'manual' && data.works_in_manual) {
+			axis_comp.current = axis(axis_val);
+		}
+	});
+
+	$effect(() => {
+		if (data.type === 'manual' && data.works_in_manual) {
+			grid_comp.current = grid(grid_val);
+		}
+	});
+</script>
+
+{#if data.type === 'auto'}
+	<Box testid="draggable" plugins={[axis(axis_val), grid(grid_val)]} />
+{:else}
+	<Box testid="draggable" plugins={() => [axis_comp, grid_comp]} />
+{/if}
+
+<br />
+
+Axis:
+
+<div>
+	<label for="x">
+		<input type="radio" id="x" bind:group={axis_val} value="x" />
+		<span>X</span>
+	</label>
+	<label for="y">
+		<input type="radio" id="y" bind:group={axis_val} value="y" />
+		<span>Y</span>
+	</label>
+</div>
+
+<br /><br />
+
+Grid:
+
+<div>
+	<label for="grid_x">
+		<input type="number" id="grid_x" bind:value={grid_val[0]} />
+		<span>X</span>
+	</label>
+	<label for="grid_y">
+		<input type="number" id="grid_y" bind:value={grid_val[1]} />
+		<span>Y</span>
+	</label>
+</div>

--- a/packages/core/test-app/src/routes/(test)/mode/+page.svelte
+++ b/packages/core/test-app/src/routes/(test)/mode/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import Box from '$lib/Box.svelte';
-	import { Compartment } from '../../../../../src/index.js';
-	import { axis, grid } from '../../../../../src/plugins.js';
+	import { axis, Compartment, grid } from '../../../../../src/plugins.js';
 
 	const { data } = $props();
 

--- a/packages/core/test-app/src/routes/+layout.svelte
+++ b/packages/core/test-app/src/routes/+layout.svelte
@@ -1,0 +1,13 @@
+<script>
+	const { children } = $props();
+</script>
+
+{@render children()}
+
+<style>
+	:global {
+		:root {
+			color-scheme: light dark;
+		}
+	}
+</style>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -95,6 +95,5 @@ export function wrapper(draggableFactory: ReturnType<typeof createDraggable>) {
 }
 
 export const useDraggable = wrapper(draggable_factory);
-export { Compartment } from '@neodrag/core';
 export * from '@neodrag/core/plugins';
 export const instances = draggable_factory.instances;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,6 +1,6 @@
 import { createDraggable } from '@neodrag/core';
 import { DragEventData, unstable_definePlugin, type Plugin } from '@neodrag/core/plugins';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const draggable_factory = createDraggable();
 
@@ -95,5 +95,6 @@ export function wrapper(draggableFactory: ReturnType<typeof createDraggable>) {
 }
 
 export const useDraggable = wrapper(draggable_factory);
+export { Compartment } from '@neodrag/core';
 export * from '@neodrag/core/plugins';
 export const instances = draggable_factory.instances;

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -1,7 +1,7 @@
 import { createDraggable } from '@neodrag/core';
 import { DragEventData, unstable_definePlugin, type Plugin } from '@neodrag/core/plugins';
-import { createSignal, onCleanup, onMount, createEffect, untrack } from 'solid-js';
 import type { Accessor, Setter } from 'solid-js';
+import { createEffect, createSignal, onCleanup, onMount } from 'solid-js';
 
 const draggable_factory = createDraggable();
 
@@ -86,5 +86,6 @@ export function wrapper(draggableFactory: ReturnType<typeof createDraggable>) {
 export const useDraggable = wrapper(draggable_factory);
 
 // Export necessary types and utilities
+export { Compartment } from '@neodrag/core';
 export * from '@neodrag/core/plugins';
 export const instances = draggable_factory.instances;

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -86,6 +86,5 @@ export function wrapper(draggableFactory: ReturnType<typeof createDraggable>) {
 export const useDraggable = wrapper(draggable_factory);
 
 // Export necessary types and utilities
-export { Compartment } from '@neodrag/core';
 export * from '@neodrag/core/plugins';
 export const instances = draggable_factory.instances;

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,4 +1,4 @@
-import { Compartment, createDraggable, type PluginResolver } from '@neodrag/core';
+import { createDraggable, type PluginResolver } from '@neodrag/core';
 import type { Plugin } from '@neodrag/core/plugins';
 import type { Action } from 'svelte/action';
 
@@ -8,5 +8,6 @@ export const draggable = core as Action<
 	HTMLElement | SVGElement,
 	Plugin[] | PluginResolver | undefined
 >;
+export { Compartment } from '@neodrag/core';
 export * from '@neodrag/core/plugins';
-export { Compartment, instances };
+export { instances };

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,13 +1,10 @@
-import { createDraggable, type PluginResolver } from '@neodrag/core';
-import type { Plugin } from '@neodrag/core/plugins';
+import { createDraggable } from '@neodrag/core';
+import type { PluginInput } from '@neodrag/core/plugins';
 import type { Action } from 'svelte/action';
 
 const { draggable: core, instances } = createDraggable();
 
-export const draggable = core as Action<
-	HTMLElement | SVGElement,
-	Plugin[] | PluginResolver | undefined
->;
-export { Compartment } from '@neodrag/core';
+export const draggable = core as Action<HTMLElement | SVGElement, PluginInput | undefined>;
+
 export * from '@neodrag/core/plugins';
 export { instances };

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,9 +1,12 @@
-import { createDraggable } from '@neodrag/core';
+import { Compartment, createDraggable, type PluginResolver } from '@neodrag/core';
 import type { Plugin } from '@neodrag/core/plugins';
 import type { Action } from 'svelte/action';
 
 const { draggable: core, instances } = createDraggable();
 
-export const draggable = core as Action<HTMLElement | SVGElement, Plugin[] | undefined>;
+export const draggable = core as Action<
+	HTMLElement | SVGElement,
+	Plugin[] | PluginResolver | undefined
+>;
 export * from '@neodrag/core/plugins';
-export { instances };
+export { Compartment, instances };

--- a/packages/vanilla/src/index.ts
+++ b/packages/vanilla/src/index.ts
@@ -1,87 +1,35 @@
-import { createDraggable } from '@neodrag/core';
+import { createDraggable, PluginResolver } from '@neodrag/core';
 import type { Plugin } from '@neodrag/core/plugins';
 
 const core = createDraggable();
 
-export class Compartment<T extends Plugin> {
-	#plugin: T;
-	#subscribers = new Set<(plugin: T) => void>();
-
-	constructor(plugin: T) {
-		this.#plugin = plugin;
-	}
-
-	subscribe(callback: (plugin: T) => void) {
-		this.#subscribers.add(callback);
-		return () => this.#subscribers.delete(callback);
-	}
-
-	set current(newPlugin: T) {
-		this.#plugin = newPlugin;
-		this.#subscribers.forEach((cb) => cb(newPlugin));
-	}
-
-	get current() {
-		return this.#plugin;
-	}
-}
-
-type CompartmentInput<T extends Plugin> = T | Compartment<T>;
-
-export class BaseDraggable {
+export class Wrapper {
 	#drag_instance: ReturnType<ReturnType<typeof createDraggable>['draggable']>;
-	#plugins: CompartmentInput<Plugin>[] = [];
-	#unsubscribers: (() => void)[] = [];
+	#plugins: Plugin[] | PluginResolver = [];
 
 	get plugins() {
 		return this.#plugins;
 	}
 
-	set plugins(plugins: CompartmentInput<Plugin>[]) {
-		this.#plugins = plugins;
-		this.#drag_instance.update(this.#resolve_plugins());
-	}
-
 	constructor(
 		factory: ReturnType<typeof createDraggable>,
 		node: HTMLElement,
-		plugins: CompartmentInput<Plugin>[] = [],
+		plugins: Plugin[] | PluginResolver = [],
 	) {
-		this.#plugins = plugins;
-		this.#setup_compartment_subscriptions();
-		this.#drag_instance = factory.draggable(node, this.#resolve_plugins());
-	}
-
-	#resolve_plugins() {
-		return this.#plugins.map((p) => (p instanceof Compartment ? p.current : p));
-	}
-
-	#setup_compartment_subscriptions() {
-		const arr: (() => void)[] = [];
-
-		for (const plugin of this.#plugins) {
-			if (plugin instanceof Compartment) {
-				arr.push(
-					plugin.subscribe(() => {
-						this.#drag_instance.update(this.#resolve_plugins());
-					}),
-				);
-			}
-		}
-		this.#unsubscribers = arr;
+		this.#drag_instance = factory.draggable(node, (this.#plugins = plugins));
 	}
 
 	destroy() {
-		this.#unsubscribers.forEach((unsub) => unsub());
 		this.#drag_instance.destroy();
 	}
 }
 
-export class Draggable extends BaseDraggable {
-	constructor(node: HTMLElement, plugins: CompartmentInput<Plugin>[] = []) {
+export class Draggable extends Wrapper {
+	constructor(node: HTMLElement, plugins: Plugin[] | PluginResolver = []) {
 		super(core, node, plugins);
 	}
 }
 
+export { Compartment } from '@neodrag/core';
 export * from '@neodrag/core/plugins';
 export const instances = core.instances;

--- a/packages/vanilla/src/index.ts
+++ b/packages/vanilla/src/index.ts
@@ -1,11 +1,11 @@
-import { createDraggable, PluginResolver } from '@neodrag/core';
-import type { Plugin } from '@neodrag/core/plugins';
+import { createDraggable } from '@neodrag/core';
+import type { PluginInput } from '@neodrag/core/plugins';
 
 const core = createDraggable();
 
 export class Wrapper {
 	#drag_instance: ReturnType<ReturnType<typeof createDraggable>['draggable']>;
-	#plugins: Plugin[] | PluginResolver = [];
+	#plugins: PluginInput = [];
 
 	get plugins() {
 		return this.#plugins;
@@ -14,7 +14,7 @@ export class Wrapper {
 	constructor(
 		factory: ReturnType<typeof createDraggable>,
 		node: HTMLElement,
-		plugins: Plugin[] | PluginResolver = [],
+		plugins: PluginInput = [],
 	) {
 		this.#drag_instance = factory.draggable(node, (this.#plugins = plugins));
 	}
@@ -25,11 +25,10 @@ export class Wrapper {
 }
 
 export class Draggable extends Wrapper {
-	constructor(node: HTMLElement, plugins: Plugin[] | PluginResolver = []) {
+	constructor(node: HTMLElement, plugins: PluginInput = []) {
 		super(core, node, plugins);
 	}
 }
 
-export { Compartment } from '@neodrag/core';
 export * from '@neodrag/core/plugins';
 export const instances = core.instances;

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,5 +1,5 @@
 import { createDraggable } from '@neodrag/core';
-import { Plugin } from '@neodrag/core/plugins';
+import type { PluginInput } from '@neodrag/core/plugins';
 import { type Directive } from 'vue';
 
 const factory = createDraggable();
@@ -8,7 +8,7 @@ const draggable_map = new WeakMap<HTMLElement | SVGElement, ReturnType<typeof fa
 
 export const wrapper = (
 	factory: ReturnType<typeof createDraggable>,
-): Directive<HTMLElement | SVGElement, Plugin[] | undefined> => {
+): Directive<HTMLElement | SVGElement, PluginInput | undefined> => {
 	return {
 		mounted: (el, { value = [] }) =>
 			!draggable_map.has(el) && draggable_map.set(el, factory.draggable(el, value)),
@@ -24,5 +24,4 @@ export const wrapper = (
 
 export const vDraggable = wrapper(factory);
 export const instances = factory.instances;
-export { Compartment } from '@neodrag/core';
 export * from '@neodrag/core/plugins';

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,6 +1,6 @@
-import { type Directive } from 'vue';
 import { createDraggable } from '@neodrag/core';
 import { Plugin } from '@neodrag/core/plugins';
+import { type Directive } from 'vue';
 
 const factory = createDraggable();
 
@@ -24,4 +24,5 @@ export const wrapper = (
 
 export const vDraggable = wrapper(factory);
 export const instances = factory.instances;
+export { Compartment } from '@neodrag/core';
 export * from '@neodrag/core/plugins';

--- a/playground/svelte/src/routes/modular/manual/+page.svelte
+++ b/playground/svelte/src/routes/modular/manual/+page.svelte
@@ -1,26 +1,29 @@
 <script>
-	import { draggable, events, position } from '@neodrag/svelte';
+	import { draggable, events, position, Compartment } from '@neodrag/svelte';
 
 	let pos = $state({ x: 0, y: 0 });
 
-	const options = $derived([
+	const positionCompartment = new Compartment(position({ current: pos }));
+
+	$effect(() => {
+		console.log(23);
+		positionCompartment.current = position({ current: $state.snapshot(pos) });
+	});
+</script>
+
+<div
+	use:draggable={() => [
 		events({
 			onDrag: ({ offset }) => {
 				pos.x = offset.x;
 				pos.y = offset.y;
 			},
 		}),
-		position({
-			current: {
-				x: pos.x,
-				y: pos.y,
-			},
-		}),
-		// disabled(),
-	]);
-</script>
-
-<div use:draggable={options}>I can be moved with the slider too</div>
+		positionCompartment,
+	]}
+>
+	I can be moved with the slider too
+</div>
 X:
 <input type="range" min="0" max="300" bind:value={pos.x} />
 Y:

--- a/playground/svelte/src/routes/modular/manual/+page.svelte
+++ b/playground/svelte/src/routes/modular/manual/+page.svelte
@@ -3,7 +3,7 @@
 
 	let pos = $state({ x: 0, y: 0 });
 
-	const positionCompartment = new Compartment(position({ current: pos }));
+	const positionCompartment = new Compartment(() => position({ current: pos }));
 
 	$effect(() => {
 		console.log(23);


### PR DESCRIPTION
This is a pretty neat way of doing fine-grained updates!

Until now, if you specified this:

```ts
use:draggable={[
		events({
			onDrag: ({ offset }) => {
				pos.x = offset.x;
				pos.y = offset.y;
			},
		}),
		position({
			current: {
				x: pos.x,
				y: pos.y,
			},
		})
]}
```

Change in `pos` would recreate the entire array and everything within it. Which is not optimal at all for performance.

However, this introduces a new concept called `Compartment`. This allows user to encapsulate a plugin in its own little "compartment". 

```ts
const axis_compartment = new Compartment(() => axis(reactive_val));
```

This creates the axis plugin once and it stays as is. Now it can be put in the plugins array alongside other regular plugins

```ts
use:draggable={() => [
		events({
			onDrag: ({ offset }) => {
				pos.x = offset.x;
				pos.y = offset.y;
			},
		}),
		axis_compartment
]}
```

> NOTE: The () => is to opt-in to the manual mode.

This new method makes the plugins option completely static. It will not be recreated again anymore whenever pos is created.

How do you inform the draggable to update? You reset the compartment:

```ts
$effect(() => {
  axis_compartment.current = axis(reactive_val);
})
```

Anytime `reactive_val` is changed, this recreates the axis plugin, and informs the Core to update internally. This approach does not touch any other plugin constructors at all, just the one plugin we update. 

This is a bit more verbose. Which is why it is opt-in. I would honestly make this the default since it makes the library small, but meh, lets try this and see if the manual method takes on better. if it, does, I can always delete the automatic way later