### PR TITLE
Fix default legacyTranslate value incosistency

### DIFF
--- a/.changeset/rare-tools-pull.md
+++ b/.changeset/rare-tools-pull.md
@@ -1,0 +1,10 @@
+---
+'@neodrag/core': patch
+'@neodrag/react': patch
+'@neodrag/solid': patch
+'@neodrag/svelte': patch
+'@neodrag/vanilla': patch
+'@neodrag/vue': patch
+---
+
+fix: ensure consistent legacyTranslate defaults to prevent double translate application

--- a/docs/src/documentation/options/legacyTranslate/+option.mdx
+++ b/docs/src/documentation/options/legacyTranslate/+option.mdx
@@ -1,7 +1,7 @@
 ---
 title: legacyTranslate
 type: 'boolean'
-defaultValue: 'true'
+defaultValue: 'false'
 deprecated: true
 deprecatedText: 'Will be removed in v3'
 ---

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -641,7 +641,7 @@ export function draggable(node: HTMLElement, options: DragOptions = {}) {
 			applyUserSelectHack = options.applyUserSelectHack ?? true;
 			grid = options.grid;
 			gpuAcceleration = options.gpuAcceleration ?? true;
-			legacyTranslate = options.legacyTranslate ?? true;
+			legacyTranslate = options.legacyTranslate ?? false;
 			transform = options.transform;
 			threshold = { ...DEFAULT_DRAG_THRESHOLD, ...(options.threshold ?? {}) };
 


### PR DESCRIPTION
Fix #199 and possibly #123 and #194.
Assuming intended default value to be `false` based on 0cead8701f132670bd5618ceeb8fdee8e9a3ad27