### PR TITLE
Feat: add bounds with offset support

### DIFF
--- a/docs/src/documentation/exported-types.mdx
+++ b/docs/src/documentation/exported-types.mdx
@@ -10,6 +10,7 @@ This package exports these types you can use:
   DragAxis,
   DragBounds,
   DragBoundsCoords,
+  DragBoundsWithOffset,
   DragOptions,
   DragEventData,
 } from '@neodrag/${props.framework}';`}
@@ -19,16 +20,18 @@ This package exports these types you can use:
 
 `DragAxis` is the type of `axis` option, and is equal to `'both' | 'x' | 'y' | 'none'`.
 
-`DragBounds` is `'parent' | string | Partial<DragBoundsCoords>`, the complete type of `bounds` option.
+`DragBounds` is `'parent' | string | Partial<DragBoundsCoords> | DragBoundsWithOffset`, the complete type of `bounds` option.
 
-`DragBoundsCoords` is when you're specifying the `bounds` field using an object, this is the type needed for that.
+`DragBoundsCoords` is when you're specifying the `bounds` field using coordinate values.
+
+`DragBoundsWithOffset` is when you're specifying the `bounds` field using an element with optional offset values.
 
 `DragEventData` is the data provided during the [events](#events)
 
 ```ts
 export type DragAxis = 'both' | 'x' | 'y' | 'none';
 
-export type DragBounds = 'parent' | string | Partial<DragBoundsCoords>;
+export type DragBounds = 'parent' | string | Partial<DragBoundsCoords> | DragBoundsWithOffset;
 
 export type DragEventData = {
   /** How much element moved from its original position horizontally */
@@ -59,5 +62,12 @@ export type DragBoundsCoords = {
 
   /** Number of pixels from the bottom of the window */
   bottom: number;
+};
+
+export type DragBoundsWithOffset = {
+  /** Element selector or HTMLElement to use as bounds container */
+  element: string | HTMLElement;
+  /** Offset values to apply to the element bounds */
+  offsets?: Partial<DragBoundsCoords>;
 };
 ```

--- a/docs/src/documentation/options/bounds/+option.mdx
+++ b/docs/src/documentation/options/bounds/+option.mdx
@@ -1,6 +1,6 @@
 ---
 title: bounds
-type: "HTMLElement | 'parent' | string | Partial<DragBoundsCoords>"
+type: "HTMLElement | 'parent' | string | Partial<DragBoundsCoords> | DragBoundsWithOffset"
 defaultValue: 'undefined'
 ---
 
@@ -11,6 +11,7 @@ import Examples from '$components/options/OptionsExamples.svelte';
 import ParentBoundsExample from './ParentBounds.example.svelte';
 import BodyBoundsExample from './BodyBounds.example.svelte';
 import CoordinateBoundsExample from './CoordinateBounds.example.svelte';
+import OffsetBoundsExample from './OffsetBounds.example.svelte';
 
 export const shortDescription = 'Optionally limit the drag area';
 
@@ -23,9 +24,11 @@ Or, you can specify any selector and it will be bound to that.
 **Note**: This library doesn't check whether the selector is bigger than the node element.
 You yourself will have to make sure of that, or it may lead to unexpected behavior.
 
-Or, finally, you can pass an object of type `DragBoundsCoords`.
+You can pass an object of type `DragBoundsCoords`.
 These mimic the css `top`, `right`, `bottom` and `left`, in the sense that `bottom` starts from the bottom of the window, and `right` from right of window.
 If any of these properties are unspecified, they are assumed to be `0`.
+
+You can also pass an object of type `DragBoundsWithOffset` to specify an element as bounds container with optional offset values applied to its boundaries.
 
 ```ts
 export type DragBoundsCoords = {
@@ -40,6 +43,13 @@ export type DragBoundsCoords = {
 
   /** Number of pixels from the bottom of the document */
   bottom: number;
+};
+
+export type DragBoundsWithOffset = {
+  /** Element selector or HTMLElement to use as bounds container */
+  element: string | HTMLElement;
+  /** Offset values to apply to the element bounds */
+  offsets?: Partial<DragBoundsCoords>;
 };
 ```
 
@@ -195,6 +205,60 @@ export type DragBoundsCoords = {
       <div slot="vanilla">
         ```js
         new Draggable(el, { bounds: { top: 60, left: 20, bottom: 35, right: 30 } });
+        ```
+      </div>
+
+    </Code>
+
+  </Example>
+
+  <Example>
+    <OffsetBoundsExample client:visible slot="demo" />
+
+    <Code slot="codes">
+      <div slot="svelte">
+        ```svelte
+        <div
+          use:draggable={{
+            bounds: { element: 'parent', offsets: { top: -30, left: -30, bottom: -30, right: -30 } },
+          }}
+        >
+          Can overflow outside parent by 30px
+        </div>
+        ```
+      </div>
+
+      <div slot="vue">
+        ```vue
+        <template>
+          <div v-draggable="{{ bounds: { element: 'parent', offsets: { top: -30, left: -30, bottom: -30, right: -30 } } }}">
+            Can overflow outside parent by 30px
+          </div>
+        </template>
+        ```
+      </div>
+
+      <div slot="solid">
+        ```jsx
+        <div use:draggable={{ bounds: { element: 'parent', offsets: { top: -30, left: -30, bottom: -30, right: -30 } } }}>
+          Can overflow outside parent by 30px
+        </div>
+        ```
+      </div>
+
+      <div slot="react">
+        ```ts
+        useDraggable(draggableRef, {
+          bounds: { element: 'parent', offsets: { top: -30, left: -30, bottom: -30, right: -30 } }
+        });
+        ```
+      </div>
+
+      <div slot="vanilla">
+        ```js
+        new Draggable(el, {
+          bounds: { element: 'parent', offsets: { top: -30, left: -30, bottom: -30, right: -30 } }
+        });
         ```
       </div>
 

--- a/docs/src/documentation/options/bounds/OffsetBounds.example.svelte
+++ b/docs/src/documentation/options/bounds/OffsetBounds.example.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import OptionsDemoBase from '$components/options/OptionsDemoBase.svelte';
+</script>
+
+<div>
+	<OptionsDemoBase options={{ bounds: { element: 'parent', offsets: { top: -30, left: -30, bottom: -30, right: -30 } } }}>
+		Offset by:
+		<code>
+			top: -30
+			<br />
+			left: -30
+			<br />
+			bottom: -30
+			<br />
+			right: -30
+		</code>
+
+		{#snippet caption()}
+			Can overflow outside parent by 30px on all sides due to negative offsets.
+		{/snippet}
+	</OptionsDemoBase>
+</div>
+
+<style lang="scss">
+	div :global(.parent) {
+		width: 90%;
+		height: 70%;
+
+		border: var(--app-color-dark) solid 2px;
+
+		border-radius: 0;
+	}
+</style>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,9 +14,17 @@ export type DragBoundsCoords = {
 
 export type DragAxis = 'both' | 'x' | 'y' | 'none';
 
+export type DragBoundsWithOffset = {
+	/** Element selector or HTMLElement to use as bounds container */
+	element: string | HTMLElement;
+	/** Offset values to apply to the element bounds */
+	offsets?: Partial<DragBoundsCoords>;
+};
+
 export type DragBounds =
 	| HTMLElement
 	| Partial<DragBoundsCoords>
+	| DragBoundsWithOffset
 	| 'parent'
 	| 'body'
 	| (string & Record<never, never>);
@@ -49,9 +57,13 @@ export type DragOptions = {
 	 * **Note**: We don't check whether the selector is bigger than the node element.
 	 * You yourself will have to make sure of that, or it may lead to strange behavior
 	 *
-	 * Or, finally, you can pass an object of type `{ top: number; right: number; bottom: number; left: number }`.
+	 * Or, you can pass an object of type `{ top: number; right: number; bottom: number; left: number }`.
 	 * These mimic the css `top`, `right`, `bottom` and `left`, in the sense that `bottom` starts from the bottom of the window, and `right` from right of window.
 	 * If any of these properties are unspecified, they are assumed to be `0`.
+	 *
+	 * You can also pass an object of type `DragBoundsWithOffset` with `{ element: string | HTMLElement, offsets?: { top?: number; right?: number; bottom?: number; left?: number } }`.
+	 * This allows you to specify an element as bounds container with optional offset values applied to its boundaries.
+	 * Example: `{ element: '.container', offsets: { top: 10, right: -200, bottom: 10, left: -200 } }`
 	 */
 	bounds?: DragBounds;
 
@@ -725,8 +737,37 @@ function compute_bound_rect(bounds: DragOptions['bounds'], rootNode: HTMLElement
 	if (is_HTMLElement(bounds)) return bounds.getBoundingClientRect();
 
 	if (typeof bounds === 'object') {
-		// we have the left right etc
+		// Check if it's a DragBoundsWithOffset object (has 'element' property)
+		if ('element' in bounds) {
+			const { element, offsets = {} } = bounds as DragBoundsWithOffset;
 
+			// Get the element's bounds
+			let elementBounds: DOMRect;
+			if (typeof element === 'string') {
+				if (element === 'parent') {
+					elementBounds = (<HTMLElement>rootNode.parentNode).getBoundingClientRect();
+				} else {
+					const el = document.querySelector<HTMLElement>(element);
+					if (!el) throw new Error(`No element found with selector: ${element}`);
+					elementBounds = el.getBoundingClientRect();
+				}
+			} else {
+				elementBounds = element.getBoundingClientRect();
+			}
+
+			// Apply offsets
+			const { top = 0, right = 0, bottom = 0, left = 0 } = offsets;
+			return {
+				top: elementBounds.top + top,
+				right: elementBounds.right - right,
+				bottom: elementBounds.bottom - bottom,
+				left: elementBounds.left + left,
+				width: elementBounds.width,
+				height: elementBounds.height
+			} as DOMRect;
+		}
+
+		// Original coordinate bounds logic
 		const { top = 0, left = 0, right = 0, bottom = 0 } = bounds;
 
 		const computed_right = window.innerWidth - right;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -96,5 +96,5 @@ export function useDraggable<RefType extends HTMLElement = HTMLDivElement>(
 	return { isDragging, dragState };
 }
 
-export type { DragAxis, DragBounds, DragBoundsCoords, DragEventData } from '@neodrag/core';
+export type { DragAxis, DragBounds, DragBoundsCoords, DragBoundsWithOffset, DragEventData } from '@neodrag/core';
 export type { ReactDragOptions as DragOptions };

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -14,6 +14,7 @@ export type {
 	DragAxis,
 	DragBounds,
 	DragBoundsCoords,
+	DragBoundsWithOffset,
 	DragEventData,
 	DragOptions,
 } from '@neodrag/core';

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -86,6 +86,7 @@ export type {
 	DragAxis,
 	DragBounds,
 	DragBoundsCoords,
+	DragBoundsWithOffset,
 	DragEventData,
 	DragOptions,
 } from '@neodrag/core';

--- a/packages/vanilla/src/index.ts
+++ b/packages/vanilla/src/index.ts
@@ -32,6 +32,7 @@ export type {
 	DragAxis,
 	DragBounds,
 	DragBoundsCoords,
+	DragBoundsWithOffset,
 	DragEventData,
 	DragOptions,
 } from '@neodrag/core';

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -19,6 +19,7 @@ export type {
 	DragAxis,
 	DragBounds,
 	DragBoundsCoords,
+	DragBoundsWithOffset,
 	DragOptions,
 	DragEventData,
 } from '@neodrag/core';


### PR DESCRIPTION
  ## Summary

  Adds `DragBoundsWithOffset` type that allows specifying an element as bounds container with optional offset values
  applied to its boundaries. This was only achievable on the viewport using `bounds`. Now it can work with any arbitrary `element`. 

  ## Changes

  - Add `DragBoundsWithOffset` type to core package
  - Update `compute_bound_rect` function to handle element bounds with offsets
  - Export new type in all framework packages (React, Svelte, Solid, Vanilla, Vue)
  - Add documentation and interactive examples
  - Update JSDoc comments with usage examples
  - Backwards compatible

  ## Usage

  ```ts
  // Allow draggable to overflow parent by 30px on all sides
  bounds: { element: 'parent', offsets: { top: -30, left: -30, bottom: -30, right: -30 } }

  // Constrain within element with 20px padding
  bounds: { element: '.container', offsets: { top: 20, left: 20, bottom: 20, right: 20 } }