### PR TITLE
fix(core): invalidate stale draggable cache

### DIFF
--- a/.changeset/tidy-pandas-drag.md
+++ b/.changeset/tidy-pandas-drag.md
@@ -1,0 +1,5 @@
+---
+'@neodrag/core': patch
+---
+
+Invalidate cached drag source lookups when their draggable root is destroyed.

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -1137,6 +1137,10 @@ export class Neodrag {
 
 	#destroyDrag(inst: DragInstance) {
 		measureCost(this, 'bind.destroy', () => {
+			if (this.#lastResult === inst.rootNode) {
+				this.#lastTarget = null;
+				this.#lastResult = null;
+			}
 			if (this.#activeSource === inst && inst.isInteracting) {
 				inst.cancelled = true;
 				this.#endActiveInteraction('cancel');
@@ -1575,4 +1579,3 @@ export class Neodrag {
 		inst.effects.clear();
 	}
 }
-

--- a/packages/core/tests/interactions/session-lifecycle.test.ts
+++ b/packages/core/tests/interactions/session-lifecycle.test.ts
@@ -147,6 +147,32 @@ describe('engine session lifecycle', () => {
 		neodrag.dispose();
 	});
 
+	it('reuses a cached child target after its drag source is destroyed', () => {
+		const neodrag = engine();
+		const rootA = createBox();
+		const rootB = createBox();
+		rootB.style.left = '200px';
+		const child = document.createElement('button');
+		rootA.appendChild(child);
+
+		const first = neodrag.draggable(rootA, []);
+		pointer(child, 'pointerdown', 60, 60);
+		pointer(child, 'pointerup', 60, 60);
+		first.destroy();
+		rootA.remove();
+
+		rootB.appendChild(child);
+		neodrag.draggable(rootB, []);
+		pointer(child, 'pointerdown', 210, 60);
+		pointer(child, 'pointermove', 225, 75);
+		pointer(child, 'pointermove', 240, 90);
+		pointer(child, 'pointerup', 240, 90);
+
+		const result = getComputedStyle(rootB).translate;
+		neodrag.dispose();
+		expect(result).toContain('30');
+	});
+
 	it('dispose removes global listeners so a new engine can be used', () => {
 		const box = createBox();
 		const first = engine();


### PR DESCRIPTION
## Summary

- invalidate the cached drag-source lookup when its draggable root is destroyed
- add a regression test that reuses the same child target under a newly registered root
- add a patch changeset for `@neodrag/core`

## Scenario

In a Svelte UI, an interactive child can populate the draggable lookup cache, then its
draggable root can be destroyed and recreated during a keyboard-driven transition. Because
restoring the UI does not produce an unrelated pointerdown, the next pointerdown can target
the exact same child node.

Clicking an unrelated UI button masks the bug because that pointerdown replaces the cached
target/result pair before the draggable UI is restored.

## Root cause

`@neodrag/core@3.0.0-next.8` cached `#last_target` / `#last_result` and returned the cached
root immediately for the same event target. The current `new-api` branch has the equivalent
`#lastTarget` / `#lastResult` fast path.

Destroying a drag source removed its instance without invalidating that cache, so the next
lookup returned the destroyed root. The instance lookup then had no matching drag source,
preventing the newly mounted root from starting its drag lifecycle.

The fix only clears the cache when `#lastResult` is the root being destroyed. The existing
map deletion behavior is unchanged because no test demonstrates a need for an identity guard.

## Regression test

The lifecycle test now:

1. registers root A with a child target
2. completes a pointer interaction on the child to cache root A
3. destroys root A's drag handle and removes root A
4. moves the same child node under root B and registers root B
5. dispatches pointerdown/pointermove events on that same child
6. verifies root B moves, proving its drag lifecycle started

Without the fix, the focused test fails with a stale-root instance lookup and root B remains
at `0px 0px`. With the fix, it passes.

## Verification

- `pnpm --filter @neodrag/core exec vitest run tests/interactions/session-lifecycle.test.ts --browser.enabled=false`
  - passed: 1 file, 7 tests
- `pnpm --dir packages/core run test:unit`
  - passed: 26 files, 89 tests
- `pnpm --dir packages/core run compile`
  - passed; tsdown completed with its declaration-emission warning
- `git diff --check`
  - passed

The repository-level `pnpm test:unit` and `pnpm compile` Turbo commands are currently blocked
before execution by the existing cyclic workspace dependency between `@neodrag/core` and
`@neodrag/svelte`; this PR does not change workspace dependencies.
